### PR TITLE
One-way Frequency-dependent light-time corrections

### DIFF
--- a/include/tudat/astro/observation_models/corrections/atmosphereCorrection.h
+++ b/include/tudat/astro/observation_models/corrections/atmosphereCorrection.h
@@ -945,8 +945,6 @@ public:
      * Constructor
      * @param referenceCorrectionCalculator Range correction calculator. Corrections based on real time data, which should
      *      read from DSN TRK-2-23 files.
-     * @param transmittedFrequencyFunction Function calculating the frequency at the current link given a vector with
-     *     the frequency bands in each link of the model and the transmission time.
      * @param baseObservableType Observable type associated with the correction.
      * @param isUplinkCorrection Boolean indicating whether correction is for uplink (i.e. transmitting station on planet,
      *      reception on spacecraft) or downlink (i.e. transmission from spacecraft, reception at ground station)
@@ -954,7 +952,6 @@ public:
      */
     TabulatedIonosphericCorrection(
             std::shared_ptr< TabulatedMediaReferenceCorrectionManager > referenceCorrectionCalculator,
-            std::function< double( std::vector< FrequencyBands > frequencyBands, double time ) > transmittedFrequencyFunction,
             ObservableType baseObservableType,
             bool isUplinkCorrection,
             double referenceFrequency = 2295e6 );
@@ -978,9 +975,6 @@ public:
 private:
     // Range correction calculator. Correction determined for referenceFrequency_
     std::shared_ptr< TabulatedMediaReferenceCorrectionManager > referenceCorrectionCalculator_;
-
-    // Frequency at the link as a function of the frequency bands per link, and of the current time
-    std::function< double( std::vector< FrequencyBands > frequencyBands, double time ) > transmittedFrequencyFunction_;
 
     // Reference frequency for which the reference corrections where calculated
     double referenceFrequency_;
@@ -1162,8 +1156,6 @@ public:
     /*!
      * Constructor.
      * @param vtecCalculator Class to calculate the vertical total electron content (VTEC)
-     * @param transmittedFrequencyFunction Function calculating the frequency at the current link given a vector with
-     *     the frequency bands in each link of the model and the transmission time.
      * @param elevationFunction Function that computes the elevation as seen from the ground station, given the vector to
      *      the target and the current time.
      * @param azimuthFunction Function that computes the azimuth as seen from the ground station, given the vector to
@@ -1178,7 +1170,6 @@ public:
      */
     MappedVtecIonosphericCorrection(
             std::shared_ptr< VtecCalculator > vtecCalculator,
-            std::function< double( std::vector< FrequencyBands > frequencyBands, double time ) > transmittedFrequencyFunction,
             std::function< double( Eigen::Vector3d inertialVectorAwayFromStation, double time ) > elevationFunction,
             std::function< double( Eigen::Vector3d inertialVectorAwayFromStation, double time ) > azimuthFunction,
             std::function< Eigen::Vector3d( double time ) > groundStationGeodeticPositionFunction,
@@ -1214,9 +1205,6 @@ public:
 private:
     // Class to calculate the vertical total electron content (VTEC)
     std::shared_ptr< VtecCalculator > vtecCalculator_;
-
-    // Frequency at the link as a function of the frequency bands per link, and of the current time
-    std::function< double( std::vector< FrequencyBands > frequencyBands, double time ) > transmittedFrequencyFunction_;
 
     // Function that computes the elevation as seen from the ground station, given the vector to the target and the current time.
     std::function< double( Eigen::Vector3d inertialVectorAwayFromStation, double time ) > elevationFunction_;

--- a/include/tudat/astro/observation_models/lightTimeSolution.h
+++ b/include/tudat/astro/observation_models/lightTimeSolution.h
@@ -317,7 +317,8 @@ public:
      *  for which solution is accepted.
      *  \return The value of the light time between the link ends.
      */
-    ObservationScalarType calculateLightTime( const TimeType time, const bool isTimeAtReception = true )
+    ObservationScalarType calculateLightTime( const TimeType time,
+                                              const bool isTimeAtReception = true )
     {
         // Declare and initialize variables for receiver and transmitter state (returned by reference).
         StateType receiverState;
@@ -381,6 +382,20 @@ public:
 
         return lightTime;
     }
+
+    ObservationScalarType calculateFirstIterationLightTime(
+        const TimeType time,
+        const bool isTimeAtReception = 1 )
+    {
+        std::vector< StateType > linkEndsStates( 2, StateType::Constant( TUDAT_NAN ) );
+        std::vector< TimeType > linkEndsTimes( 2, TUDAT_NAN );
+
+        ObservationScalarType lightTime = calculateLightTimeWithMultiLegLinkEndsStates(
+            linkEndsStates, linkEndsTimes, time, isTimeAtReception, 0, nullptr, false );
+
+        return lightTime;
+    }
+
 
     //! Function to calculate the light time and link-ends states, given an initial guess for all legs.
     /*!
@@ -658,6 +673,19 @@ public:
     std::shared_ptr< ephemerides::Ephemeris > getEphemerisOfReceivingBody( )
     {
         return ephemerisOfReceivingBody_;
+    }
+
+    bool doCorrectionsNeedFrequency( )
+    {
+        bool correctionsNeedFrequency = false;
+        for( int i = 0; i < correctionFunctions_.size( ); i++ )
+        {
+            if( requiresMultiLegIterations( correctionFunctions_.at( i )->getLightTimeCorrectionType() ) )
+            {
+                correctionsNeedFrequency = true;
+            }
+        }
+        return correctionsNeedFrequency;
     }
 
 protected:

--- a/include/tudat/astro/observation_models/observationModel.h
+++ b/include/tudat/astro/observation_models/observationModel.h
@@ -20,6 +20,7 @@
 #include "tudat/astro/observation_models/observableTypes.h"
 #include "tudat/astro/observation_models/observationBias.h"
 #include "tudat/astro/observation_models/observationFrequencies.h"
+#include "tudat/astro/ground_stations/groundStation.h"
 #include "tudat/basics/basicTypedefs.h"
 #include "tudat/basics/timeType.h"
 #include "tudat/basics/tudatTypeTraits.h"
@@ -379,6 +380,8 @@ inline std::shared_ptr< ObservationAncilliarySimulationSettings > getDefaultAnci
     }
     return ancilliarySettings;
 }
+
+
 
 //! Base class for models of observables (i.e. range, range-rate, etc.).
 /*!

--- a/include/tudat/astro/system_models/vehicleSystems.h
+++ b/include/tudat/astro/system_models/vehicleSystems.h
@@ -416,6 +416,16 @@ public:
         return totalNumberOfPanels_;
     }
 
+    std::shared_ptr< ground_stations::StationFrequencyInterpolator > getTransmittedFrequencyCalculator( )
+    {
+        return transmittedFrequencyCalculator_;
+    }
+
+    void setTransmittedFrequencyCalculator( const std::shared_ptr< ground_stations::StationFrequencyInterpolator > transmittedFrequencyCalculator )
+    {
+        transmittedFrequencyCalculator_ = transmittedFrequencyCalculator;
+    }
+
 private:
     std::map< std::string, std::shared_ptr< ephemerides::Ephemeris > > referencePoints_;
 
@@ -452,6 +462,9 @@ private:
 
     std::function< double( observation_models::FrequencyBands uplinkBand, observation_models::FrequencyBands downlinkBand ) >
             transponderTurnaroundRatio_;
+
+    std::shared_ptr< ground_stations::StationFrequencyInterpolator > transmittedFrequencyCalculator_;
+
 };
 
 }  // namespace system_models

--- a/include/tudat/simulation/estimation_setup/createObservationModel.h
+++ b/include/tudat/simulation/estimation_setup/createObservationModel.h
@@ -1952,16 +1952,24 @@ public:
                 }
 
                 // Create observation model
-                observationModel = std::make_shared< OneWayRangeObservationModel< ObservationScalarType, TimeType > >(
+                std::shared_ptr< observation_models::LightTimeCalculator< ObservationScalarType, TimeType > > lightTimeCalculator =
+                    createLightTimeCalculator< ObservationScalarType, TimeType >( linkEnds,
+                                                                              transmitter,
+                                                                              receiver,
+                                                                              bodies,
+                                                                              topLevelObservableType,
+                                                                              observationSettings->lightTimeCorrectionsList_,
+                                                                              observationSettings->lightTimeConvergenceCriteria_ );
+                std::shared_ptr< OneWayRangeObservationModel< ObservationScalarType, TimeType > >
+                    oneWayRangeObservationModel = std::make_shared< OneWayRangeObservationModel< ObservationScalarType, TimeType > >(
                         linkEnds,
-                        createLightTimeCalculator< ObservationScalarType, TimeType >( linkEnds,
-                                                                                      transmitter,
-                                                                                      receiver,
-                                                                                      bodies,
-                                                                                      topLevelObservableType,
-                                                                                      observationSettings->lightTimeCorrectionsList_,
-                                                                                      observationSettings->lightTimeConvergenceCriteria_ ),
+                        lightTimeCalculator,
                         observationBias );
+                if( lightTimeCalculator->doCorrectionsNeedFrequency( ) )
+                {
+                    oneWayRangeObservationModel->setFrequencyInterpolator(
+                        getTransmittingFrequencyInterpolator( bodies, linkEnds ) );
+                }
 
                 break;
             }

--- a/src/astro/observation_models/corrections/atmosphereCorrection.cpp
+++ b/src/astro/observation_models/corrections/atmosphereCorrection.cpp
@@ -761,12 +761,11 @@ double SaastamoinenTroposphericCorrection::computeWetZenithRangeCorrection( cons
 
 TabulatedIonosphericCorrection::TabulatedIonosphericCorrection(
         std::shared_ptr< TabulatedMediaReferenceCorrectionManager > referenceCorrectionCalculator,
-        std::function< double( std::vector< FrequencyBands > frequencyBands, double time ) > transmittedFrequencyFunction,
         ObservableType baseObservableType,
         bool isUplinkCorrection,
         double referenceFrequency ):
     LightTimeCorrection( tabulated_ionospheric ), referenceCorrectionCalculator_( referenceCorrectionCalculator ),
-    transmittedFrequencyFunction_( transmittedFrequencyFunction ), referenceFrequency_( referenceFrequency ),
+    referenceFrequency_( referenceFrequency ),
     isUplinkCorrection_( isUplinkCorrection )
 {
     if( isRadiometricObservableType( baseObservableType ) )
@@ -938,7 +937,6 @@ double JakowskiVtecCalculator::calculateVtec( const double time, const Eigen::Ve
 
 MappedVtecIonosphericCorrection::MappedVtecIonosphericCorrection(
         std::shared_ptr< VtecCalculator > vtecCalculator,
-        std::function< double( std::vector< FrequencyBands > frequencyBands, double time ) > transmittedFrequencyFunction,
         std::function< double( Eigen::Vector3d inertialVectorAwayFromStation, double time ) > elevationFunction,
         std::function< double( Eigen::Vector3d inertialVectorAwayFromStation, double time ) > azimuthFunction,
         std::function< Eigen::Vector3d( double time ) > groundStationGeodeticPositionFunction,
@@ -948,7 +946,7 @@ MappedVtecIonosphericCorrection::MappedVtecIonosphericCorrection(
         LightTimeCorrectionType correctionType,
         double firstOrderDelayCoefficient ):
     LightTimeCorrection( correctionType ), vtecCalculator_( vtecCalculator ),
-    transmittedFrequencyFunction_( transmittedFrequencyFunction ), elevationFunction_( elevationFunction ),
+    elevationFunction_( elevationFunction ),
     azimuthFunction_( azimuthFunction ), groundStationGeodeticPositionFunction_( groundStationGeodeticPositionFunction ),
     bodyWithAtmosphereMeanEquatorialRadius_( bodyWithAtmosphereMeanEquatorialRadius ),
     firstOrderDelayCoefficient_( firstOrderDelayCoefficient ), isUplinkCorrection_( isUplinkCorrection )

--- a/src/simulation/estimation_setup/createLightTimeCorrection.cpp
+++ b/src/simulation/estimation_setup/createLightTimeCorrection.cpp
@@ -408,7 +408,6 @@ std::shared_ptr< LightTimeCorrection > createLightTimeCorrections( const std::sh
                             ionosphericCorrectionSettings->getReferenceRangeCorrection( )
                                     .at( stationSpacecraftPair )
                                     .at( baseObservableType ),
-                            createLinkFrequencyFunction( bodies, linkEnds, transmittingLinkEndType, receivingLinkEndType ),
                             baseObservableType,
                             isUplinkCorrection,
                             ionosphericCorrectionSettings->getReferenceFrequency( ) );
@@ -539,7 +538,6 @@ std::shared_ptr< LightTimeCorrection > createLightTimeCorrections( const std::sh
 
                 lightTimeCorrection = std::make_shared< MappedVtecIonosphericCorrection >(
                         vtecCalculator,
-                        createLinkFrequencyFunction( bodies, linkEnds, transmittingLinkEndType, receivingLinkEndType ),
                         elevationFunction,
                         azimuthFunction,
                         groundStationGeodeticPositionFunction,
@@ -636,7 +634,6 @@ std::shared_ptr< LightTimeCorrection > createLightTimeCorrections( const std::sh
 
                 lightTimeCorrection = std::make_shared< MappedVtecIonosphericCorrection >(
                         vtecCalculator,
-                        createLinkFrequencyFunction( bodies, linkEnds, transmittingLinkEndType, receivingLinkEndType ),
                         elevationFunction,
                         azimuthFunction,
                         groundStationGeodeticPositionFunction,
@@ -902,10 +899,43 @@ std::function< double( std::vector< FrequencyBands >, double ) > createLinkFrequ
         const LinkEndType& transmittingLinkEndType,
         const LinkEndType& receivingLinkEndType )
 {
-    std::shared_ptr< ground_stations::StationFrequencyInterpolator > transmittedFrequencyCalculator =
-            bodies.getBody( linkEnds.at( transmitter ).bodyName_ )
-                    ->getGroundStation( linkEnds.at( transmitter ).stationName_ )
-                    ->getTransmittingFrequencyCalculator( );
+    std::shared_ptr< ground_stations::StationFrequencyInterpolator > transmittedFrequencyCalculator;
+
+    if( bodies.getBody( linkEnds.at( transmitter ).bodyName_ )->getGroundStationMap( ).count( linkEnds.at( transmitter ).stationName_ ) > 0 )
+    {
+        if( bodies.getBody( linkEnds.at( transmitter ).bodyName_ )
+                ->getGroundStation( linkEnds.at( transmitter ).stationName_ )
+                ->getTransmittingFrequencyCalculator( ) != nullptr )
+        {
+            transmittedFrequencyCalculator = bodies.getBody( linkEnds.at( transmitter ).bodyName_ )
+                ->getGroundStation( linkEnds.at( transmitter ).stationName_ )
+                ->getTransmittingFrequencyCalculator( );
+        }
+        else
+        {
+            throw std::runtime_error( "Error when creating link frequency function, no transmitter found in station " +
+                                          linkEnds.at( transmitter ).bodyName_ + "; " + linkEnds.at( transmitter ).stationName_ );
+        }
+    }
+    else if( bodies.getBody( linkEnds.at( transmitter ).bodyName_ )->getVehicleSystems( ) != nullptr )
+    {
+        if( bodies.getBody( linkEnds.at( transmitter ).bodyName_ )->getVehicleSystems( )->getTransmittedFrequencyCalculator( ) != nullptr )
+        {
+            transmittedFrequencyCalculator = bodies.getBody( linkEnds.at( transmitter ).bodyName_ )
+                ->getVehicleSystems( )->getTransmittedFrequencyCalculator( );
+        }
+        else
+        {
+            throw std::runtime_error( "Error when creating link frequency function, no transmitter found in vehicle systems of " +
+                                      linkEnds.at( transmitter ).bodyName_ );
+        }
+    }
+    else
+    {
+        throw std::runtime_error( "Error when creating link frequency function, " +
+                                  linkEnds.at( transmitter ).bodyName_ + "; " + linkEnds.at( transmitter ).stationName_ +
+                                  " has not transmitter in either the vehicle systems of station" );
+    }
 
     std::vector< std::function< double( FrequencyBands, FrequencyBands ) > > turnaroundRatioFunctions;
 

--- a/tests/src/astro/observation_models/unitTestAtmosphereCorrection.cpp
+++ b/tests/src/astro/observation_models/unitTestAtmosphereCorrection.cpp
@@ -441,8 +441,6 @@ BOOST_AUTO_TEST_CASE( testJakowskiIonosphericCorrectionGodot )
             };
             std::function< double( double ) > sunDeclinationFunction = [ = ]( double time ) { return sunDeclinations.at( j ); };
             std::function< double( double ) > f10p7FluxFunction = [ = ]( double time ) { return f10p7Fluxes.at( j ); };
-            std::function< double( std::vector< FrequencyBands >, double ) > frequencyFunction =
-                    [ = ]( std::vector< FrequencyBands > freqBands, double time ) { return frequencies.at( j ); };
             std::function< double( Eigen::Vector3d, double ) > elevationFunction = [ = ]( Eigen::Vector3d inertialVectorAwayFromStation,
                                                                                           double time ) { return elevations.at( j ); };
             std::function< double( Eigen::Vector3d, double ) > azimuthFunction = [ = ]( Eigen::Vector3d inertialVectorAwayFromStation,
@@ -455,7 +453,6 @@ BOOST_AUTO_TEST_CASE( testJakowskiIonosphericCorrectionGodot )
             // Create ionospheric correction model
             MappedVtecIonosphericCorrection ionosphericCorrection =
                     MappedVtecIonosphericCorrection( vtecCalculator,
-                                                     frequencyFunction,
                                                      elevationFunction,
                                                      azimuthFunction,
                                                      groundStationGeodeticPositionFunction,


### PR DESCRIPTION
This draft PR is to address this issue:

https://github.com/orgs/tudat-team/discussions/26

The modifications are as follows:
* Remove the no longer needed `std::function< double( std::vector< FrequencyBands > frequencyBands, double time ) > transmittedFrequencyFunction_` in the frequency-dependent light time corrections
* Add the possibility of the vehicle systems to possess a frequency interpolator, to support spacecraft as transmitters

As a first implementation, I'm working on adding the frequency-dependent corrections to the one-way range. Once this is working, we can generalize to all (one- and two-way) observables. Doing this requires two types of changes:
1. The frequency-dependent corrections are currently only supported for observations that already require the observed/computed frequency (e.g. Doppler)
2. The frequency-dependent corrections are currently only supported for n-way observations

To address the first point, I propose to:
* Add a frequency transmitter to the one-way range observation model. This only gets set if the light-time calculator has any frequency dependent correction models
* If the observation model sees it has a frequency calculator, it will set the transmitter_frequency_intermediate and received_frequency_intermediate quantities in the ancillary settings. These are the frequencies that are used in the correction models. These frequencies can be an approximation, and ignore the Doppler shift. For the one-way observation, they are equal. For two-way observations they are offset by the turnaround ratio.

To address the second point, only a minor change needs to be added: (I think) allowing an approximate computation of the 1-way light time calculator (now only implemented in the n-way model)